### PR TITLE
time_elapsed misused

### DIFF
--- a/scripts/arm_mover
+++ b/scripts/arm_mover
@@ -48,12 +48,12 @@ def move_arm(pos_j1, pos_j2):
 
 def handle_safe_move_request(req):
 
-    time_elapsed = rospy.Time.now()
+    #time_elapsed = rospy.Time.now() # 
 
     rospy.loginfo('GoToPositionRequest Received - j1:%s, j2:%s',
                    req.joint_1, req.joint_2)
     clamp_j1, clamp_j2 = clamp_at_boundaries(req.joint_1, req.joint_2)
-    move_arm(clamp_j1, clamp_j2)
+    time_elapsed = move_arm(clamp_j1, clamp_j2)
     time_elapsed = rospy.Time.now() - time_elapsed
 
     return GoToPositionResponse(time_elapsed)


### PR DESCRIPTION
time_elapsed is defined in move_arm function and returned. we are not using it and instead, we create another time_elapsed inside handle_safe_move_request function. so I modified the code to use the time_elapsed  value returned from move_arm function