### PR TITLE
Feat - add safe_spawner to ensure startup timings

### DIFF
--- a/scripts/safe_spawner.sh
+++ b/scripts/safe_spawner.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+# This script safely launches ros nodes with buffer time to allow arm_mover service to start up in time
+x-terminal-emulator -e roslaunch simple_arm robot_spawn.launch &
+sleep 5 &&
+x-terminal-emulator -e ./look_away


### PR DESCRIPTION
I added a safe_spawner script to fix the race condition when starting up the look_ahead node. I reported this issue in Waffle ticket #104 and using this script to start up can fix the bug.