### PR TITLE
Fixed launching robot on ROS Melodic Morenia (Ubuntu 18.04)

### DIFF
--- a/urdf/simple_arm.urdf.xacro
+++ b/urdf/simple_arm.urdf.xacro
@@ -224,7 +224,7 @@
   <transmission name="tran1">
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="joint_1">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
     </joint>
     <actuator name="motor1">
       <hardwareInterface>EffortJointInterface</hardwareInterface>
@@ -235,7 +235,7 @@
   <transmission name="tran2">
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="joint_2">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
     </joint>
     <actuator name="motor2">
       <hardwareInterface>EffortJointInterface</hardwareInterface>


### PR DESCRIPTION
--Description:

When launching the robot (`roslaunch simple_arm robot_spawn.launch`) there were some errors logged:

[INFO] [1548020597.935127, 261.179000]: Spawn status: SpawnModel: Entity pushed to spawn queue, but spawn service timed out waiting for entity to appear in simulation under the name simple_arm
[ERROR] [1548020597.935741, 261.180000]: Spawn service failed. Exiting.
...
[urdf_spawner-7] process has died [pid 13774, exit code 1, cmd /opt/ros/melodic/lib/gazebo_ros/spawn_model -urdf -param robot_description -x 0 -y 0 -z 0 -R 0 -P 0 -Y 0 -model simple_arm __name:=urdf_spawner __log:=/home/m/.ros/log/653659c0-1cfc-11e9-b3ab-503eaa5a35be/urdf_spawner-7.log].

Seems that the source of the error was the deprecated syntax, logged few lines later:

[ WARN] [1548020598.434896422, 261.239000000]: Deprecated syntax, please prepend 'hardware_interface/' to 'EffortJointInterface' within the <hardwareInterface> tag in joint 'joint_1'.
[ WARN] [1548020598.435778731, 261.239000000]: Deprecated syntax, please prepend 'hardware_interface/' to 'EffortJointInterface' within the <hardwareInterface> tag in joint 'joint_2'.

--Fix:

The thing was to follow the suggestion given in warning and add missing `hardware_interface/` prefix